### PR TITLE
Remove package.json which proxied to jekyll

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,0 @@
-{
-  "private": true,
-  "scripts": {
-    "build": "jekyll build && mv _site public"
-  }
-}


### PR DESCRIPTION
Based on the example in
https://github.com/zeit/now/tree/e10b42bfdce7c770312d97791e676acaa3bcda60
it is no longer necessary.